### PR TITLE
update to use venv

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.8'
+# version: '3.8'
 
 services:
   db:

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -3,16 +3,17 @@ FROM alpine:3.19
 # Set the working directory
 WORKDIR /app
 # Update packages and install python3, pip, libpq, libpq-dev, gcc, musl-dev and python3-dev
-RUN apk add --no-cache tzdata
-ENV TZ=America/Chicago
-RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 RUN apk update && \
     apk add --no-cache python3 py3-pip libpq libpq-dev gcc musl-dev python3-dev
-# Install the Python dependencies
+# Install the Python dependencies after setting up the virtual environment
+ENV VIRTUAL_ENV=/opt/venv
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 COPY Code/Server/requirements.txt /app/
-RUN pip install --no-cache-dir --break-system-packages -r /app/requirements.txt
+RUN pip install --no-cache-dir -r /app/requirements.txt
 # Remove pip, libpq-dev, gcc, musl-dev and python3-dev
 RUN apk del py3-pip libpq-dev gcc musl-dev python3-dev
+RUN pip uninstall -y pip
 # Copy the server script into the Docker image
 COPY Code/Server/server.py /app/server.py
 COPY Code/Server/my_database.py /app/my_database.py


### PR DESCRIPTION
This allows me to use the virtual environment in python to make sure I don't break packages in the base os. Also I remove pip to make sure not to trigger the cve for pip being installed. Also I have removed the version: '3.8' from the docker-compose.yml file.